### PR TITLE
Allow to be built for iOS 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "wishkit-ios",
     platforms: [
         .macOS(.v12),
-        .iOS(.v14)
+        .iOS(.v12)
     ],
     products: [
         .library(name: "WishKit", targets: ["WishKit"])

--- a/README.md
+++ b/README.md
@@ -18,12 +18,19 @@ WishKit allows your users to request and vote on features in your app that <b>ju
 <img src="Resources/banner-min.png" />
 
 ## Index
+- [Requirements](#requirements)
 - [Setup (UIKit)](#uikit)
 - [Setup (SwiftUI)](#swiftui)
 - [Theming](#theming)
 - [User Segmentation](#user-segmentation)
 - [Control UI Elements](#ui-elements)
 - [Localization](#localization)
+
+# Requirements
+
+The framework builds for iOS 12+, but all functionality requires iOS 14+. So for any app using WishKit
+as a dependency that supports iOS 12 or 13, you will need to add `if #available(iOS 14, *) { }` code
+around any use of WishKit.
 
 # UIKit
 

--- a/Sources/WishKit/API/Api.swift
+++ b/Sources/WishKit/API/Api.swift
@@ -9,12 +9,14 @@
 import Foundation
 import WishKitShared
 
+@available(iOS 14, *)
 struct Api: RequestCreatable {
     enum Version: String {
         case v1
     }
 }
 
+@available(iOS 14, *)
 enum ApiResult<Success, Error> {
     case success(Success)
     case failure(Error)
@@ -22,6 +24,7 @@ enum ApiResult<Success, Error> {
 
 // MARK: - Generic Send Functions
 
+@available(iOS 14, *)
 extension Api {
     /// Generic Send Function. You need to specify the Result<T, Error> type to help inferring it.
     /// e.g: Api.send(request: resetRequest) { (result: Result<ResetPasswordResponse, ApiError.Kind>) in ... }

--- a/Sources/WishKit/API/CommentApi.swift
+++ b/Sources/WishKit/API/CommentApi.swift
@@ -9,6 +9,7 @@
 import Foundation
 import WishKitShared
 
+@available(iOS 14, *)
 struct CommentApi: RequestCreatable {
 
     private static let baseUrl = "\(ProjectSettings.apiUrl)"

--- a/Sources/WishKit/API/RequestCreatable.swift
+++ b/Sources/WishKit/API/RequestCreatable.swift
@@ -8,8 +8,10 @@
 
 import Foundation
 
+@available(iOS 14, *)
 protocol RequestCreatable {}
 
+@available(iOS 14, *)
 extension RequestCreatable {
 
     /// Create a POST request with JSON body
@@ -73,6 +75,7 @@ extension RequestCreatable {
     }
 }
 
+@available(iOS 14, *)
 extension URLRequest {
 
     /// Adds User UUID and Bearer token to URLRequest if given.

--- a/Sources/WishKit/API/UserApi.swift
+++ b/Sources/WishKit/API/UserApi.swift
@@ -9,6 +9,7 @@
 import Foundation
 import WishKitShared
 
+@available(iOS 14, *)
 struct UserApi: RequestCreatable {
 
     private static let baseUrl = "\(ProjectSettings.apiUrl)"

--- a/Sources/WishKit/API/WishApi.swift
+++ b/Sources/WishKit/API/WishApi.swift
@@ -9,6 +9,7 @@
 import Foundation
 import WishKitShared
 
+@available(iOS 14, *)
 struct WishApi: RequestCreatable {
 
     private static let baseUrl = "\(ProjectSettings.apiUrl)"

--- a/Sources/WishKit/Configuration+Localization.swift
+++ b/Sources/WishKit/Configuration+Localization.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Martin Lasek. All rights reserved.
 //
 
+@available(iOS 14, *)
 extension Configuration {
 
     public struct Localization {

--- a/Sources/WishKit/Configuration/Config+AddButton.swift
+++ b/Sources/WishKit/Configuration/Config+AddButton.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension Configuration {
     public struct AddButton {
         public var display: Display = .show
@@ -22,6 +23,7 @@ extension Configuration {
     }
 }
 
+@available(iOS 14, *)
 extension Configuration.AddButton {
     public enum Padding {
         case small

--- a/Sources/WishKit/Configuration/Config+Buttons.swift
+++ b/Sources/WishKit/Configuration/Config+Buttons.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Martin Lasek. All rights reserved.
 //
 
+@available(iOS 14, *)
 extension Configuration {
     public struct Buttons {
 

--- a/Sources/WishKit/Configuration/Config+DoneButton.swift
+++ b/Sources/WishKit/Configuration/Config+DoneButton.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension Configuration {
     public struct DoneButton {
 

--- a/Sources/WishKit/Configuration/Config+SaveButton.swift
+++ b/Sources/WishKit/Configuration/Config+SaveButton.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension Configuration {
     public struct SaveButton {
         

--- a/Sources/WishKit/Configuration/Config+SegmentedControl.swift
+++ b/Sources/WishKit/Configuration/Config+SegmentedControl.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension Configuration {
     public struct SegmentedControl {
 

--- a/Sources/WishKit/Configuration/Config+TabBar.swift
+++ b/Sources/WishKit/Configuration/Config+TabBar.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension Configuration {
     public struct TabBar {
 

--- a/Sources/WishKit/Configuration/Config+VoteButton.swift
+++ b/Sources/WishKit/Configuration/Config+VoteButton.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension Configuration {
     public struct VoteButton {
 

--- a/Sources/WishKit/Configuration/Configuration.swift
+++ b/Sources/WishKit/Configuration/Configuration.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 14, *)
 public struct Configuration {
 
     /// Hides/Shows the status badge of a wish e.g. "Approved" or "Implemented".
@@ -40,6 +41,7 @@ public struct Configuration {
 
 // MARK: - Display
 
+@available(iOS 14, *)
 extension Configuration {
     public enum Display {
         case show
@@ -49,6 +51,7 @@ extension Configuration {
 
 // MARK: - Email Field
 
+@available(iOS 14, *)
 extension Configuration {
     public enum EmailField {
         case none

--- a/Sources/WishKit/Extensions/Button+Compat.swift
+++ b/Sources/WishKit/Extensions/Button+Compat.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension Button {
 
     @ViewBuilder

--- a/Sources/WishKit/Extensions/List+Compat.swift
+++ b/Sources/WishKit/Extensions/List+Compat.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension View {
     
     @ViewBuilder

--- a/Sources/WishKit/Extensions/ProgressView+Compat.swift
+++ b/Sources/WishKit/Extensions/ProgressView+Compat.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension ProgressView {
 
     @ViewBuilder

--- a/Sources/WishKit/Extensions/ScrollView+Compat.swift
+++ b/Sources/WishKit/Extensions/ScrollView+Compat.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension ScrollView {
     func refreshableCompat(action: @escaping @Sendable () async -> Void) -> some View {
         if #available(iOS 15, *) {

--- a/Sources/WishKit/Extensions/ToolbarCompat.swift
+++ b/Sources/WishKit/Extensions/ToolbarCompat.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension View {
     @ViewBuilder
     func toolbarKeyboardDoneButton() -> some View {

--- a/Sources/WishKit/Extensions/View+Shadow.swift
+++ b/Sources/WishKit/Extensions/View+Shadow.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 extension View {
     func wkShadow() -> some View {
         if WishKit.config.dropShadow == .show {

--- a/Sources/WishKit/Model/AlertModel.swift
+++ b/Sources/WishKit/Model/AlertModel.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 final class AlertModel: ObservableObject {
 
     enum AlertReason {

--- a/Sources/WishKit/Model/CommentModel.swift
+++ b/Sources/WishKit/Model/CommentModel.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 final class CommentModel: ObservableObject {
     @Published
     var newCommentValue = ""

--- a/Sources/WishKit/Model/MockData.swift
+++ b/Sources/WishKit/Model/MockData.swift
@@ -9,6 +9,7 @@
 import WishKitShared
 import Foundation
 
+@available(iOS 14, *)
 struct MockData {
     static var wishlist: [WishResponse] {
         let wishlist = [

--- a/Sources/WishKit/Model/WishModel.swift
+++ b/Sources/WishKit/Model/WishModel.swift
@@ -11,6 +11,7 @@ import WishKitShared
 import Foundation
 import SwiftUI
 
+@available(iOS 14, *)
 final class WishModel: ObservableObject {
 
     @Published

--- a/Sources/WishKit/ProjectSettings.swift
+++ b/Sources/WishKit/ProjectSettings.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 14, *)
 struct ProjectSettings {
     static var apiUrl: String {
         let wishKitUrl = ProcessInfo.processInfo.environment["wishkit-url"]

--- a/Sources/WishKit/SwiftUI/AddButton.swift
+++ b/Sources/WishKit/SwiftUI/AddButton.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 struct AddButton: View {
     
     @Environment(\.colorScheme)
@@ -64,6 +65,7 @@ struct AddButton: View {
     }
 }
 
+@available(iOS 14, *)
 struct RoundButtonStyle: ButtonStyle {
 
     func makeBody(configuration: Self.Configuration) -> some View {
@@ -74,6 +76,7 @@ struct RoundButtonStyle: ButtonStyle {
     }
 }
 
+@available(iOS 14, *)
 extension ButtonStyle where Self == RoundButtonStyle {
     static var roundButtonStyle: RoundButtonStyle {
         RoundButtonStyle()

--- a/Sources/WishKit/SwiftUI/CloseButton.swift
+++ b/Sources/WishKit/SwiftUI/CloseButton.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 struct CloseButton: View {
 
     private let closeAction: () -> Void

--- a/Sources/WishKit/SwiftUI/CommentFieldView.swift
+++ b/Sources/WishKit/SwiftUI/CommentFieldView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import WishKitShared
 
+@available(iOS 14, *)
 struct CommentFieldView: View {
 
     @Environment(\.colorScheme)
@@ -63,6 +64,7 @@ struct CommentFieldView: View {
     }
 }
 
+@available(iOS 14, *)
 extension CommentFieldView {
 
     var textColor: Color {

--- a/Sources/WishKit/SwiftUI/CommentListView.swift
+++ b/Sources/WishKit/SwiftUI/CommentListView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import WishKitShared
 
+@available(iOS 14, *)
 struct CommentListView: View {
 
     @Binding

--- a/Sources/WishKit/SwiftUI/CreateWishView.swift
+++ b/Sources/WishKit/SwiftUI/CreateWishView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import Combine
 import WishKitShared
 
+@available(iOS 14, *)
 struct CreateWishView: View {
 
     @Environment(\.presentationMode)
@@ -298,6 +299,7 @@ struct CreateWishView: View {
 
 // MARK: - Color Scheme
 
+@available(iOS 14, *)
 extension CreateWishView {
 
     var textColor: Color {

--- a/Sources/WishKit/SwiftUI/DetailWishView.swift
+++ b/Sources/WishKit/SwiftUI/DetailWishView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import WishKitShared
 import Combine
 
+@available(iOS 14, *)
 struct DetailWishView: View {
 
     // MARK: - Private
@@ -107,6 +108,7 @@ struct DetailWishView: View {
 
 // MARK: - Color Scheme
 
+@available(iOS 14, *)
 extension DetailWishView {
 
     var backgroundColor: Color {

--- a/Sources/WishKit/SwiftUI/SegmentedView.swift
+++ b/Sources/WishKit/SwiftUI/SegmentedView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import WishKitShared
 
+@available(iOS 14, *)
 struct SegmentedView: View {
 
     @Binding
@@ -25,6 +26,7 @@ struct SegmentedView: View {
     }
 }
 
+@available(iOS 14, *)
 extension WishState: Identifiable {
     public var id: Self { self }
 

--- a/Sources/WishKit/SwiftUI/SeparatorView.swift
+++ b/Sources/WishKit/SwiftUI/SeparatorView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 struct SeparatorView: View {
     var body: some View {
         HStack(alignment: .center) {

--- a/Sources/WishKit/SwiftUI/SingleCommentView.swift
+++ b/Sources/WishKit/SwiftUI/SingleCommentView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 struct SingleCommentView: View {
 
     @Environment(\.colorScheme)

--- a/Sources/WishKit/SwiftUI/WKButton.swift
+++ b/Sources/WishKit/SwiftUI/WKButton.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 struct WKButton: View {
 
     @Environment(\.colorScheme)
@@ -88,6 +89,7 @@ struct WKButton: View {
 
 // MARK: - ButtonStyle
 
+@available(iOS 14, *)
 extension WKButton {
     enum ButtonStyle {
         case primary

--- a/Sources/WishKit/SwiftUI/WishView.swift
+++ b/Sources/WishKit/SwiftUI/WishView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import WishKitShared
 
+@available(iOS 14, *)
 struct WishView: View {
 
     // Helps differentiate where this view is used (in the list or in detail view).
@@ -197,6 +198,7 @@ struct WishView: View {
 
 // MARK: - Darkmode
 
+@available(iOS 14, *)
 extension WishView {
     var arrowColor: Color {
         let userUUID = UUIDManager.getUUID()

--- a/Sources/WishKit/SwiftUI/iOS+Catalyst/WishlistView+iOS.swift
+++ b/Sources/WishKit/SwiftUI/iOS+Catalyst/WishlistView+iOS.swift
@@ -11,6 +11,7 @@ import SwiftUI
 import WishKitShared
 import Combine
 
+@available(iOS 14, *)
 extension View {
     // MARK: Public - Wrap in Navigation
 
@@ -22,6 +23,7 @@ extension View {
     }
 }
 
+@available(iOS 14, *)
 struct WishlistViewIOS: View {
 
     @Environment(\.colorScheme)
@@ -174,6 +176,7 @@ struct WishlistViewIOS: View {
     }
 }
 
+@available(iOS 14, *)
 extension WishlistViewIOS {
     var arrowColor: Color {
         let userUUID = UUIDManager.getUUID()

--- a/Sources/WishKit/Theme.swift
+++ b/Sources/WishKit/Theme.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 14, *)
 public struct Theme {
 
     /// This is for the Add-Button, Segmented Control, and Vote-Button.
@@ -46,6 +47,7 @@ public struct Theme {
     #endif
 }
 
+@available(iOS 14, *)
 struct PrivateTheme {
     struct ColorScheme {
         let light: Color
@@ -65,6 +67,7 @@ struct PrivateTheme {
 
 // MARK: - StatusBadge
 
+@available(iOS 14, *)
 extension Theme {
     public struct BadgeTheme {
 
@@ -94,6 +97,7 @@ extension Theme {
     }
 }
 
+@available(iOS 14, *)
 extension Theme {
     public struct Scheme {
         var light: Color

--- a/Sources/WishKit/User.swift
+++ b/Sources/WishKit/User.swift
@@ -8,6 +8,7 @@
 
 import WishKitShared
 
+@available(iOS 14, *)
 final class User {
     var customID: String?
     var email: String?

--- a/Sources/WishKit/Utils/WKHostingController.swift
+++ b/Sources/WishKit/Utils/WKHostingController.swift
@@ -8,6 +8,7 @@
 #if canImport(UIKit)
 import SwiftUI
 
+@available(iOS 14, *)
 final class WKHostingController<Content>: UIHostingController<Content> where Content: View {
     override init(rootView: Content) {
         super.init(rootView: rootView)

--- a/Sources/WishKit/WishKit.swift
+++ b/Sources/WishKit/WishKit.swift
@@ -14,6 +14,7 @@ import SwiftUI
 import WishKitShared
 import Combine
 
+@available(iOS 14, *)
 public struct WishKit {
     
     private static var subscribers: Set<AnyCancellable> = []
@@ -49,6 +50,7 @@ public struct WishKit {
 
 // MARK: - Payment Model
 
+@available(iOS 14, *)
 class RoundUp: NSDecimalNumberBehaviors {
     func scale() -> Int16 {
         return 0
@@ -63,6 +65,7 @@ class RoundUp: NSDecimalNumberBehaviors {
     }
 }
 
+@available(iOS 14, *)
 public struct Payment {
 
     let amount: Int
@@ -95,6 +98,7 @@ public struct Payment {
 
 // MARK: - Update User Logic
 
+@available(iOS 14, *)
 extension WishKit {
     public static func updateUser(customID: String) {
         self.user.customID = customID


### PR DESCRIPTION
While everything is marked @available(iOS 14, *), this now allows the project to be imported into apps that support iOS 12+. Of course, the target app will have to use if #available(iOS 14, *) around WishKit functionality.